### PR TITLE
1Week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+application-secret.yml

--- a/records/1Week_LeeYulhee.md
+++ b/records/1Week_LeeYulhee.md
@@ -1,0 +1,58 @@
+## Title: [1Week] 이율희
+
+### 미션 요구사항 분석 & 체크리스트
+
+---
+
+### 필수 미션 : 호감 상대 삭제 ###
+
+- **목표**
+
+    - 호감 목록 페이지에서 특정 항목의 삭제 버튼을 누르면, 해당 항목은 삭제되어야 한다.
+
+        - 삭제를 처리하기 전에 해당 항목에 대한 소유권이 본인(로그인한 사람)에게 있는지 체크해야 한다.
+    - 삭제 후 다시 호감 목록 페이지로 돌아와야 한다.
+
+        - rq.redirectWithMsg 함수 사용
+
+**[LikeablePerson Controller & Service & Repository]**
+- [X] list.html에 구현되어 있는 삭제 버튼에 연결된 URL 확인
+- [X] Controller에 GetMapping으로 삭제 기능에 대한 URL 연결
+- [X] Controller의 delete 메서드에 LikeablePerson에 대한 객체 생성 후, LikeablePerson에 대한 정보 대입
+- [X] Controller의 delete 메서드에서 객체에 대한 정보가 들어오면 Service의 delete 메서드 실행
+- [X] Service에 delete 메서드 생성하고 Repository의 delete 메서드(이건 따로 생성할 필요 없음) 실행
+
+**[Rq 및 RsData에 대한 내용 파악 후 맞춰서 재구현]**
+- [X] Rq 및 RsData에 대한 내용 및 Member 클래스쪽 구현 내용 보며 파악
+- [X] Controller의 delete 메서드의 return 값을 rq.redirectWithMsg로 변경
+- [X] 삭제를 처리하기 전에 로그인한 사람과 해당 호감 상대를 등록한 사람이 같은지 확인하는 과정 필요
+
+### 1주차 미션 요약
+
+---
+
+**[접근 방법]**
+
+- list.html에 th:href="@{|delete/${likeablePerson.id}|} 부분 확인해서 해당 부분을 Controller의 URL로 매핑
+- {likeablePerson.id} 부분을 받기 위해 @PathVariable로 id 값을 받고, 매개변수로 넣음
+- return redirect: 로 list URL 매핑
+- SBB의 질문, 답변 삭제하는 부분을 참고해 Question question = this.questionService.getQuestion(id) 처럼 Service에서 id로 정보를 받아 객체 생성
+- SBB를 따라 throw Exception을 작성했지만 오류 나서 다시 지우고, this.likeablePersonService.delete(likeableperson) 작성
+- 오류를 따라 Service로 이동해 this.likeablePersonRepository.delete(likeablePerson) 작성
+- 큰 흐름 및 대략적인 메서드를 작성하기 위해 위의 과정을 실행했으나 당연하게도 오류 발생 및 미션 조건 미충족
+- Controller에서 delete 메서드의 return을 rq.redirectWithMsg 변경
+- 오류를 따라서 rq 클래스 및 RsData 클래스 확인, 이미 해당 클래스들로 구현되어 있는 Member쪽 클래스들 확인
+- 오류를 하나씩 수정해가며 챗GPT 및 SBB, 복습 강의들 참고. 디버깅으로 URL로 잘 이동되는지 확인하고 DB에 삭제 여부 확인해가며 진행
+
+    - 이 부분은 오류를 수정하며 이해가 안 가는 부분들을 주먹구구식으로 풀어 나감
+
+
+**[특이사항]**
+
+- SBB를 위주로 공부했어서 강사님이 구현하며 리팩토링한 코드가 익숙치 않아 어려웠다.
+- 시간이 촉박해서 필요한 부분들만 빠르게 훑으며 넘겼는데 Rq 클래스와 RsData에 대해서는 시간이 있을 때 다시 한 번 제대로 공부해야겠다.
+- SBB 따라쓰기를 틈틈이 할 필요성을 느꼈다.
+
+**[Refactoring]**
+- 전반적으로 지저분한 부분이나 더 깔끔하게 표현할 수 있는 부분들 확인
+- 메서드나 기능들의 구현이 알맞은 클래스에 위치하고 있는지

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -26,6 +26,7 @@ public class NotProd {
             Member memberUser4 = memberService.join("user4", "1234").getData();
 
             Member memberUser5ByKakao = memberService.whenSocialLogin("KAKAO", "KAKAO__2733218491").getData();
+            Member memberUser6ByGoogle = memberService.whenSocialLogin("GOOGLE", "GOOGLE__102791966327743347703").getData();
 
             instaMemberService.connect(memberUser2, "insta_user2", "M");
             instaMemberService.connect(memberUser3, "insta_user3", "W");

--- a/src/main/java/com/ll/gramgram/base/rq/Rq.java
+++ b/src/main/java/com/ll/gramgram/base/rq/Rq.java
@@ -69,6 +69,8 @@ public class Rq {
         String key = "historyBackErrorMsg___" + referer;
         req.setAttribute("localStorageKeyAboutHistoryBackErrorMsg", key);
         req.setAttribute("historyBackErrorMsg", msg);
+        // 200 이 아니라 400 으로 응답코드가 지정되도록
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         return "common/js";
     }
 

--- a/src/main/java/com/ll/gramgram/boundedContext/home/controller/HomeController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/home/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.ll.gramgram.boundedContext.home.controller;
 
+import com.ll.gramgram.base.rq.Rq;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -11,6 +12,8 @@ import java.util.Enumeration;
 @Controller
 @RequiredArgsConstructor
 public class HomeController {
+    private final Rq rq;
+
     @GetMapping("/")
     public String showMain() {
         return "usr/home/main";
@@ -29,5 +32,10 @@ public class HomeController {
         }
 
         return sb.toString().replaceAll("\n", "<br>");
+    }
+
+    @GetMapping("/historyBackTest")
+    public String showHistoryBackTest(HttpSession session) {
+        return rq.historyBack("여기는 당신같은 사람이 오면 안되요.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/entity/InstaMember.java
@@ -1,12 +1,17 @@
 package com.ll.gramgram.boundedContext.instaMember.entity;
 
+import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -29,4 +34,24 @@ public class InstaMember {
     private String username;
     @Setter
     private String gender;
+
+    @OneToMany(mappedBy = "fromInstaMember", cascade = {CascadeType.ALL})
+    @OrderBy("id desc") // 정렬
+    @LazyCollection(LazyCollectionOption.EXTRA)
+    @Builder.Default // @Builder 가 있으면 ` = new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
+    private List<LikeablePerson> fromLikeablePeople = new ArrayList<>();
+
+    @OneToMany(mappedBy = "toInstaMember", cascade = {CascadeType.ALL})
+    @OrderBy("id desc") // 정렬
+    @LazyCollection(LazyCollectionOption.EXTRA)
+    @Builder.Default // @Builder 가 있으면 ` = new ArrayList<>();` 가 작동하지 않는다. 그래서 이걸 붙여야 한다.
+    private List<LikeablePerson> toLikeablePeople = new ArrayList<>();
+
+    public void addFromLikeablePerson(LikeablePerson likeablePerson) {
+        fromLikeablePeople.add(0, likeablePerson); // @OrderBy("id desc") 때문에 앞으로 넣는다.
+    }
+
+    public void addToLikeablePerson(LikeablePerson likeablePerson) {
+        toLikeablePeople.add(0, likeablePerson); // @OrderBy("id desc") 때문에 앞으로 넣는다.
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -9,12 +9,10 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
@@ -26,6 +24,7 @@ public class LikeablePersonController {
     private final Rq rq;
     private final LikeablePersonService likeablePersonService;
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/add")
     public String showAdd() {
         return "usr/likeablePerson/add";
@@ -38,6 +37,7 @@ public class LikeablePersonController {
         private final int attractiveTypeCode;
     }
 
+    @PreAuthorize("isAuthenticated()")
     @PostMapping("/add")
     public String add(@Valid AddForm addForm) {
         RsData<LikeablePerson> createRsData = likeablePersonService.like(rq.getMember(), addForm.getUsername(), addForm.getAttractiveTypeCode());
@@ -49,26 +49,33 @@ public class LikeablePersonController {
         return rq.redirectWithMsg("/likeablePerson/list", createRsData);
     }
 
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/list")
     public String showList(Model model) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
-            List<LikeablePerson> likeablePeople = likeablePersonService.findByFromInstaMemberId(instaMember.getId());
+            // 해당 인스타회원이 좋아하는 사람들 목록
+            List<LikeablePerson> likeablePeople = instaMember.getFromLikeablePeople();
             model.addAttribute("likeablePeople", likeablePeople);
         }
 
         return "usr/likeablePerson/list";
     }
 
-    @GetMapping("/delete/{id}")
-    public String delete(@PathVariable("id") Long id) {
-        RsData<LikeablePerson> deleteRsData = likeablePersonService.delete(rq.getMember(), id);
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/{id}")
+    public String delete(@PathVariable Long id) {
+        LikeablePerson likeablePerson = likeablePersonService.findById(id).orElse(null);
 
-        if (deleteRsData.isFail()) {
-            return rq.historyBack(deleteRsData);
-        }
+        RsData canActorDeleteRsData = likeablePersonService.canActorDelete(rq.getMember(), likeablePerson);
+
+        if (canActorDeleteRsData.isFail()) return rq.historyBack(canActorDeleteRsData);
+
+        RsData deleteRsData = likeablePersonService.delete(likeablePerson);
+
+        if (deleteRsData.isFail()) return rq.historyBack(deleteRsData);
 
         return rq.redirectWithMsg("/likeablePerson/list", deleteRsData);
     }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -61,4 +61,15 @@ public class LikeablePersonController {
 
         return "usr/likeablePerson/list";
     }
+
+    @GetMapping("/delete/{id}")
+    public String delete(@PathVariable("id") Long id) {
+        RsData<LikeablePerson> deleteRsData = likeablePersonService.delete(rq.getMember(), id);
+
+        if (deleteRsData.isFail()) {
+            return rq.historyBack(deleteRsData);
+        }
+
+        return rq.redirectWithMsg("/likeablePerson/list", deleteRsData);
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/entity/LikeablePerson.java
@@ -28,11 +28,15 @@ public class LikeablePerson {
     private LocalDateTime modifyDate;
 
     @ManyToOne
+    @ToString.Exclude // 양방향을 걸면, 여기에 달아주는게 보통이다. 이렇게 해야 무한재귀가 실행되지 않는다.
     private InstaMember fromInstaMember; // 호감을 표시한 사람(인스타 멤버)
     private String fromInstaMemberUsername; // 혹시 몰라서 기록
+
     @ManyToOne
+    @ToString.Exclude // 양방향을 걸면, 여기에 달아주는게 보통이다. 이렇게 해야 무한재귀가 실행되지 않는다.
     private InstaMember toInstaMember; // 호감을 받은 사람(인스타 멤버)
     private String toInstaMemberUsername; // 혹시 몰라서 기록
+
     private int attractiveTypeCode; // 매력포인트(1=외모, 2=성격, 3=능력)
 
     public String getAttractiveTypeDisplayName() {

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Integer> {
+public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
-
-    Optional<LikeablePerson> findById(Long id);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Integer> {
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
+
+    Optional<LikeablePerson> findById(Long id);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -22,7 +23,7 @@ public class LikeablePersonService {
 
     @Transactional
     public RsData<LikeablePerson> like(Member member, String username, int attractiveTypeCode) {
-        if ( member.hasConnectedInstaMember() == false ) {
+        if (member.hasConnectedInstaMember() == false) {
             return RsData.of("F-2", "먼저 본인의 인스타그램 아이디를 입력해야 합니다.");
         }
 
@@ -30,11 +31,12 @@ public class LikeablePersonService {
             return RsData.of("F-1", "본인을 호감상대로 등록할 수 없습니다.");
         }
 
+        InstaMember fromInstaMember = member.getInstaMember();
         InstaMember toInstaMember = instaMemberService.findByUsernameOrCreate(username).getData();
 
         LikeablePerson likeablePerson = LikeablePerson
                 .builder()
-                .fromInstaMember(member.getInstaMember()) // 호감을 표시하는 사람의 인스타 멤버
+                .fromInstaMember(fromInstaMember) // 호감을 표시하는 사람의 인스타 멤버
                 .fromInstaMemberUsername(member.getInstaMember().getUsername()) // 중요하지 않음
                 .toInstaMember(toInstaMember) // 호감을 받는 사람의 인스타 멤버
                 .toInstaMemberUsername(toInstaMember.getUsername()) // 중요하지 않음
@@ -43,6 +45,12 @@ public class LikeablePersonService {
 
         likeablePersonRepository.save(likeablePerson); // 저장
 
+        // 너가 좋아하는 호감표시 생겼어.
+        fromInstaMember.addFromLikeablePerson(likeablePerson);
+
+        // 너를 좋아하는 호감표시 생겼어.
+        toInstaMember.addToLikeablePerson(likeablePerson);
+
         return RsData.of("S-1", "입력하신 인스타유저(%s)를 호감상대로 등록되었습니다.".formatted(username), likeablePerson);
     }
 
@@ -50,22 +58,29 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
 
+    public Optional<LikeablePerson> findById(Long id) {
+        return likeablePersonRepository.findById(id);
+    }
+
     @Transactional
-    public RsData<LikeablePerson> delete(Member member, Long id) {
-        Optional<LikeablePerson> likeablePersonOpt = likeablePersonRepository.findById(id);
-
-        if (likeablePersonOpt.isEmpty()) {
-            return RsData.of("F-1", "해당 호감상대가 존재하지 않습니다.");
-        }
-
-        LikeablePerson likeablePerson = likeablePersonOpt.get();
-
-        if (likeablePerson.getFromInstaMember().getId() != member.getInstaMember().getId()) {
-            return RsData.of("F-2", "해당 호감상대를 삭제할 권한이 없습니다.");
-        }
-
+    public RsData delete(LikeablePerson likeablePerson) {
         likeablePersonRepository.delete(likeablePerson);
 
-        return RsData.of("S-1", "해당 호감상대를 삭제하였습니다.");
+        String likeCanceledUsername = likeablePerson.getToInstaMember().getUsername();
+        return RsData.of("S-1", "%s님에 대한 호감을 취소하였습니다.".formatted(likeCanceledUsername));
+    }
+
+    public RsData canActorDelete(Member actor, LikeablePerson likeablePerson) {
+        if (likeablePerson == null) return RsData.of("F-1", "이미 삭제되었습니다.");
+
+        // 수행자의 인스타계정 번호
+        long actorInstaMemberId = actor.getInstaMember().getId();
+        // 삭제 대상의 작성자(호감표시한 사람)의 인스타계정 번호
+        long fromInstaMemberId = likeablePerson.getFromInstaMember().getId();
+
+        if (actorInstaMemberId != fromInstaMemberId)
+            return RsData.of("F-2", "권한이 없습니다.");
+
+        return RsData.of("S-1", "삭제가능합니다.");
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -49,4 +49,23 @@ public class LikeablePersonService {
     public List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId) {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
     }
+
+    @Transactional
+    public RsData<LikeablePerson> delete(Member member, Long id) {
+        Optional<LikeablePerson> likeablePersonOpt = likeablePersonRepository.findById(id);
+
+        if (likeablePersonOpt.isEmpty()) {
+            return RsData.of("F-1", "해당 호감상대가 존재하지 않습니다.");
+        }
+
+        LikeablePerson likeablePerson = likeablePersonOpt.get();
+
+        if (likeablePerson.getFromInstaMember().getId() != member.getInstaMember().getId()) {
+            return RsData.of("F-2", "해당 호감상대를 삭제할 권한이 없습니다.");
+        }
+
+        likeablePersonRepository.delete(likeablePerson);
+
+        return RsData.of("S-1", "해당 호감상대를 삭제하였습니다.");
+    }
 }

--- a/src/main/resources/application-secret.yml.default
+++ b/src/main/resources/application-secret.yml.default
@@ -1,0 +1,10 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            clientId: '카카오 클라이언트 ID'
+          google:
+            clientId: '구글 클라이언트 ID'
+            client-secret: '구글 클라이언트 시크릿'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
   profiles:
     active: dev
+    include: secret
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     url: jdbc:mariadb://127.0.0.1:3306/gram_dev?useUnicode=true&characterEncoding=utf8&autoReconnect=true&serverTimezone=Asia/Seoul
@@ -11,12 +16,15 @@ spring:
       client:
         registration:
           kakao:
-            clientId: 34c57fed809ec8aa31d6340f598beba4
             scope:
             client-name: Kakao
             authorization-grant-type: authorization_code
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
             client-authentication-method: POST
+          google:
+            redirect-uri: '{baseUrl}/{action}/oauth2/code/{registrationId}'
+            client-name: Google
+            scope: profile
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -34,6 +42,6 @@ spring:
 logging:
   level:
     root: INFO
-    com.ll.gramgram_ai: DEBUG
+    com.ll.gramgram: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE

--- a/src/main/resources/templates/usr/home/main.html
+++ b/src/main/resources/templates/usr/home/main.html
@@ -8,6 +8,8 @@
 
 <main layout:fragment="main">
     메인입니다.
+
+    <a class="btn btn-link" href="/historyBackTest">히스토리 백 테스트</a>
 </main>
 
 </body>

--- a/src/main/resources/templates/usr/instaMember/connect.html
+++ b/src/main/resources/templates/usr/instaMember/connect.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('인스타그램 아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -27,7 +27,7 @@
 
             const $checkedGenderRadioButton = $(form).find("[name=gender]:checked");
 
-            if ($checkedGenderRadioButton.length == 0) {
+            if ($checkedGenderRadioButton.length === 0) {
                 toastWarning('성별을 선택해주세요.');
                 $(form).find("[name=gender]:first").focus();
                 return;

--- a/src/main/resources/templates/usr/layout/layout.html
+++ b/src/main/resources/templates/usr/layout/layout.html
@@ -40,6 +40,7 @@
     <a href="javascript:;" th:if="${@rq.login}" onclick="$(this).next().submit();" class="btn btn-link">로그아웃</a>
     <form th:if="${@rq.login}" hidden th:action="|/member/logout|" method="POST"></form>
     <span th:if="${@rq.login}" th:text="|${@rq.member.username}님 환영합니다.|"></span>
+    <span th:if="${@rq.login and @rq.member.hasConnectedInstaMember()}" th:text="|(${#lists.size(@rq.member.instaMember.toLikeablePeople)}/${#lists.size(@rq.member.instaMember.fromLikeablePeople)})|"></span>
 </header>
 
 <main layout:fragment="main"></main>
@@ -64,6 +65,13 @@
         if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
             toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
             localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+        } else if ( !document.referrer ) {
+            const localStorageKeyAboutHistoryBackErrorMsg = "historyBackErrorMsg___null";
+
+            if (localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg)) {
+                toastWarning(localStorage.getItem(localStorageKeyAboutHistoryBackErrorMsg));
+                localStorage.removeItem(localStorageKeyAboutHistoryBackErrorMsg);
+            }
         }
     });
 </script>
@@ -71,5 +79,3 @@
 </body>
 
 </html>
-
-

--- a/src/main/resources/templates/usr/likeablePerson/add.html
+++ b/src/main/resources/templates/usr/likeablePerson/add.html
@@ -6,7 +6,7 @@
 
 <body>
 
-<mai layout:fragment="main">
+<main layout:fragment="main">
     <th:block th:unless="${@rq.member.hasConnectedInstaMember}">
         <div>먼저 본인의 인스타그램 아이디를 입력해주세요.</div>
 
@@ -17,14 +17,14 @@
 
     <th:block th:if="${@rq.member.hasConnectedInstaMember}">
         <script th:inline="javascript">
-            const myInstaMember = /*[[ ${@rq.member.instaMember} ]]*/ null;
+            const myInstaMemberUsername = /*[[ ${@rq.member.instaMember.username} ]]*/ null;
 
             function AddForm__submit(form) {
                 // username 이(가) 올바른지 체크
 
                 form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-                if (form.username.value.length == 0) {
+                if (form.username.value.length === 0) {
                     toastWarning('상대방의 인스타그램 아이디를 입력해주세요.');
                     form.username.focus();
                     return;
@@ -36,7 +36,7 @@
                     return;
                 }
 
-                if (form.username.value == myInstaMember.username) {
+                if (form.username.value === myInstaMemberUsername) {
                     toastWarning('본인을 호감상대로 등록할 수 없습니다.');
                     form.username.focus();
                     return;
@@ -44,7 +44,7 @@
 
                 const $checkedAttractiveTypeCodeRadioButton = $(form).find("[name=attractiveTypeCode]:checked");
 
-                if ($checkedAttractiveTypeCodeRadioButton.length == 0) {
+                if ($checkedAttractiveTypeCodeRadioButton.length === 0) {
                     toastWarning('상대방의 매력포인트를 선택해주세요.');
                     $(form).find("[name=attractiveTypeCode]:first").focus();
                     return;
@@ -88,7 +88,7 @@
             </div>
         </form>
     </th:block>
-</mai>
+</main>
 </body>
 
 </html>

--- a/src/main/resources/templates/usr/likeablePerson/list.html
+++ b/src/main/resources/templates/usr/likeablePerson/list.html
@@ -6,7 +6,7 @@
 
 <body>
 
-<mai layout:fragment="main">
+<main layout:fragment="main">
     <th:block th:unless="${@rq.member.hasConnectedInstaMember}">
         <div>먼저 본인의 인스타그램 아이디를 입력해주세요.</div>
 
@@ -21,12 +21,14 @@
                 <span class="toInstaMember_username" th:text="${likeablePerson.toInstaMember.username}"></span>
                 <span class="toInstaMember_attractiveTypeDisplayName"
                       th:text="${likeablePerson.attractiveTypeDisplayName}"></span>
-                <a th:href="@{|delete/${likeablePerson.id}|}" onclick="return confirm('정말로 삭제하시겠습니까?');">삭제</a>
+                <a href="javascript:;" onclick="if ( confirm('정말로 삭제하시겠습니까?') ) $(this).next().submit();">삭제</a>
+                <form hidden th:action="@{|/likeablePerson/${likeablePerson.id}|}" method="POST">
+                    <input type="hidden" name="_method" value="delete">
+                </form>
             </li>
         </ul>
     </th:block>
-</mai>
+</main>
 </body>
 
 </html>
-

--- a/src/main/resources/templates/usr/member/join.html
+++ b/src/main/resources/templates/usr/member/join.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -29,7 +29,7 @@
 
             form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.password.value.length == 0) {
+            if (form.password.value.length === 0) {
                 form.password.focus();
                 toastWarning('비밀번호를 입력해주세요.');
                 return;

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -13,7 +13,7 @@
 
             form.username.value = form.username.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.username.value.length == 0) {
+            if (form.username.value.length === 0) {
                 toastWarning('아이디를 입력해주세요.');
                 form.username.focus();
                 return;
@@ -29,7 +29,7 @@
 
             form.password.value = form.password.value.trim(); // 입력란의 입력값에 있을지 모르는 좌우공백제거
 
-            if (form.password.value.length == 0) {
+            if (form.password.value.length === 0) {
                 form.password.focus();
                 toastWarning('비밀번호를 입력해주세요.');
                 return;
@@ -63,7 +63,7 @@
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/google">
-            구글 로그인하기(아직 안됨)
+            구글 로그인하기
         </a>
 
         <a class="btn btn-link" href="/oauth2/authorization/naver">

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -1,6 +1,7 @@
 package com.ll.gramgram.boundedContext.likeablePerson.controller;
 
 
+import com.ll.gramgram.boundedContext.likeablePerson.service.LikeablePersonService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,10 +13,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -26,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class LikeablePersonControllerTests {
     @Autowired
     private MockMvc mvc;
+    @Autowired
+    private LikeablePersonService likeablePersonService;
 
     @Test
     @DisplayName("등록 폼(인스타 인증을 안해서 폼 대신 메세지)")
@@ -148,5 +151,70 @@ public class LikeablePersonControllerTests {
                         <span class="toInstaMember_attractiveTypeDisplayName">성격</span>
                         """.stripIndent().trim())));
         ;
+    }
+
+    @Test
+    @DisplayName("호감삭제")
+    @WithUserDetails("user3")
+    void t006() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/likeablePerson/1")
+                                .with(csrf())
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/likeablePerson/list**"))
+        ;
+
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("호감삭제(없는거 삭제, 삭제가 안되어야 함)")
+    @WithUserDetails("user3")
+    void t007() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/likeablePerson/100")
+                                .with(csrf())
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is4xxClientError())
+        ;
+    }
+
+    @Test
+    @DisplayName("호감삭제(권한이 없는 경우, 삭제가 안됨)")
+    @WithUserDetails("user2")
+    void t008() throws Exception {
+        // WHEN
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/likeablePerson/1")
+                                .with(csrf())
+                )
+                .andDo(print());
+
+        // THEN
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(status().is4xxClientError())
+        ;
+
+        assertThat(likeablePersonService.findById(1L).isPresent()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## Title: [1Week] 이율희

### 미션 요구사항 분석 & 체크리스트

---

### 필수 미션 : 호감 상대 삭제 ###

- **목표**

    - 호감 목록 페이지에서 특정 항목의 삭제 버튼을 누르면, 해당 항목은 삭제되어야 한다.

        - 삭제를 처리하기 전에 해당 항목에 대한 소유권이 본인(로그인한 사람)에게 있는지 체크해야 한다.
    - 삭제 후 다시 호감 목록 페이지로 돌아와야 한다.

        - rq.redirectWithMsg 함수 사용

**[LikeablePerson Controller & Service & Repository]**
- [X] list.html에 구현되어 있는 삭제 버튼에 연결된 URL 확인
- [X] Controller에 GetMapping으로 삭제 기능에 대한 URL 연결
- [X] Controller의 delete 메서드에 LikeablePerson에 대한 객체 생성 후, LikeablePerson에 대한 정보 대입
- [X] Controller의 delete 메서드에서 객체에 대한 정보가 들어오면 Service의 delete 메서드 실행
- [X] Service에 delete 메서드 생성하고 Repository의 delete 메서드(이건 따로 생성할 필요 없음) 실행

**[Rq 및 RsData에 대한 내용 파악 후 맞춰서 재구현]**
- [X] Rq 및 RsData에 대한 내용 및 Member 클래스쪽 구현 내용 보며 파악
- [X] Controller의 delete 메서드의 return 값을 rq.redirectWithMsg로 변경
- [X] 삭제를 처리하기 전에 로그인한 사람과 해당 호감 상대를 등록한 사람이 같은지 확인하는 과정 필요

### 1주차 미션 요약

---

**[접근 방법]**

- list.html에 th:href="@{|delete/${likeablePerson.id}|} 부분 확인해서 해당 부분을 Controller의 URL로 매핑
- {likeablePerson.id} 부분을 받기 위해 @PathVariable로 id 값을 받고, 매개변수로 넣음
- return redirect: 로 list URL 매핑
- SBB의 질문, 답변 삭제하는 부분을 참고해 Question question = this.questionService.getQuestion(id) 처럼 Service에서 id로 정보를 받아 객체 생성
- SBB를 따라 throw Exception을 작성했지만 오류 나서 다시 지우고, this.likeablePersonService.delete(likeableperson) 작성
- 오류를 따라 Service로 이동해 this.likeablePersonRepository.delete(likeablePerson) 작성
- 큰 흐름 및 대략적인 메서드를 작성하기 위해 위의 과정을 실행했으나 당연하게도 오류 발생 및 미션 조건 미충족
- Controller에서 delete 메서드의 return을 rq.redirectWithMsg 변경
- 오류를 따라서 rq 클래스 및 RsData 클래스 확인, 이미 해당 클래스들로 구현되어 있는 Member쪽 클래스들 확인
- 오류를 하나씩 수정해가며 챗GPT 및 SBB, 복습 강의들 참고. 디버깅으로 URL로 잘 이동되는지 확인하고 DB에 삭제 여부 확인해가며 진행

    - 이 부분은 오류를 수정하며 이해가 안 가는 부분들을 주먹구구식으로 풀어 나감


**[특이사항]**

- SBB를 위주로 공부했어서 강사님이 구현하며 리팩토링한 코드가 익숙치 않아 어려웠다.
- 시간이 촉박해서 필요한 부분들만 빠르게 훑으며 넘겼는데 Rq 클래스와 RsData에 대해서는 시간이 있을 때 다시 한 번 제대로 공부해야겠다.
- SBB 따라쓰기를 틈틈이 할 필요성을 느꼈다.

**[Refactoring]**
- 전반적으로 지저분한 부분이나 더 깔끔하게 표현할 수 있는 부분들 확인
- 메서드나 기능들의 구현이 알맞은 클래스에 위치하고 있는지